### PR TITLE
Add command line parameter parsing

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -2,14 +2,14 @@
 """
 Usage: %(script_name)s { -h | --help }
        %(script_name)s [ { -c | --config-file } FILE ]
-            [ { -i | --telegram-id } UUID }
+            [ { -t | --telegram-id } UUID }
 
 Start the Telegram/Zabbix bot.
 
 Arguments:
     -h, --help      This message
     -c FILE, --config-file FILE     The location of the config file.
-    -i UUID, --telegram-id UUID     The UUID of your Telegram bot as returned
+    -t UUID, --telegram-id UUID     The UUID of your Telegram bot as returned
                     by @BotFather. It is discouraged to specify this on the
                     command line (although it is useful for testing); use
                     the config file instead.
@@ -29,10 +29,12 @@ def usage():
 
 
 def parse_commandline(argv = sys.argv[1:]):
+    cmdline_config = {}
+
     try:
         optlist, args = getopt.getopt(
                 argv,
-                'c:hi:',
+                'c:ht:',
                 [ 'config-file=', 'help', 'telegram-id=' ]
         )
     except getopt.GetoptError as err:
@@ -42,28 +44,50 @@ def parse_commandline(argv = sys.argv[1:]):
         sys.exit(1)
 
     for opt, arg in optlist:
-        # TODO Parse command line options
-        pass
+        if opt in ('-h', '--help'):
+            usage()
+            sys.exit(0)
+        elif opt in ('-c', '--config-file'):
+            cmdline_config['config-file'] = arg
+        elif opt in ('-t', '--telegram-id'):
+            cmdline_config['telegram-id'] = arg
+        else:
+            assert False, 'Unhandled command line option [%(opt)s]' % {'opt': opt};
 
+    return cmdline_config
 
 
 def main():
     logging.basicConfig(format='%(message)s')
 
-    parse_commandline()
+    cmdline_config = parse_commandline()
 
-    config = configparser.ConfigParser()
-
+    configfile_parser = configparser.ConfigParser()
     # Open settings.ini file to retrieve API token
     try:
-            with open('settings.ini') as f:
-                    config.read_file(f)
+            with open(cmdline_config['config-file'] if 'config-file' in cmdline_config else 'settings.ini') as f:
+                    configfile_parser.read_file(f)
     except:
             e = sys.exc_info()[1]
             print(e)
             sys.exit(1)
 
-    token = config.get('TelegramSettings','API-Token')
+    # Put configuration in the actual config dictionary. Use the value specified
+    # on the command line if it has a value, fall back to the config file if it
+    # does not.
+    config = {}
+    for cmdline_option, configfile_option, name in [
+        ( 'telegram-id', ('TelegramSettings', 'API-Token'), 'telegram-API-token' ),
+    ]:
+        print("Parsing config option %(name)s" % {'name': name})
+        config[name] = cmdline_config[cmdline_option] if cmdline_option in cmdline_config else configfile_parser.get(configfile_option[0], configfile_option[1], fallback=None)
+
+    token = config['telegram-API-token']
+
+    if token == '':
+        log = logging.getLogger(__name__)
+        log.error('No Telegram API token specified. Configure it in the config file or specify it on the command line')
+        sys.exit(1)
 
     # initialise Bot
     try:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,4 +1,30 @@
 import sys, configparser, telebot
+import getopt
+import logging
+
+
+logging.basicConfig(format='%(message)s')
+log = logging.getLogger(__name__)
+
+
+def usage():
+    pass
+
+def parse_commandline(argv = sys.argv[1:]):
+    try:
+        optlist, args = getopt.getopt(
+                argv,
+                'c:h',
+                [ 'config-file=', 'help' ]
+        )
+    except getopt.GetoptError as err:
+        log.error('Error parsing command line options: %s', err)
+        usage()
+        sys.exit(1)
+
+
+
+parse_commandline()
 
 config = configparser.ConfigParser()
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,3 +1,22 @@
+"""
+Usage: %(script_name)s { -h | --help }
+       %(script_name)s [ { -c | --config-file } FILE ]
+            [ { -i | --telegram-id } UUID }
+
+Start the Telegram/Zabbix bot.
+
+Arguments:
+    -h, --help      This message
+    -c FILE, --config-file FILE     The location of the config file.
+    -i UUID, --telegram-id UUID     The UUID of your Telegram bot as returned
+                    by @BotFather. It is discouraged to specify this on the
+                    command line (although it is useful for testing); use
+                    the config file instead.
+
+Command line arguments override their equivalent settings in the config file
+when specified.
+"""
+
 import sys, configparser, telebot
 import getopt
 import logging
@@ -8,20 +27,24 @@ log = logging.getLogger(__name__)
 
 
 def usage():
-    pass
+    print (__doc__ % {'script_name': sys.argv[0].split('/')[-1]}, file=sys.stderr)
+
 
 def parse_commandline(argv = sys.argv[1:]):
     try:
         optlist, args = getopt.getopt(
                 argv,
-                'c:h',
-                [ 'config-file=', 'help' ]
+                'c:hi:',
+                [ 'config-file=', 'help', 'telegram-id=' ]
         )
     except getopt.GetoptError as err:
         log.error('Error parsing command line options: %s', err)
         usage()
         sys.exit(1)
 
+    for opt, arg in optlist:
+        # TODO Parse command line options
+        pass
 
 
 parse_commandline()

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -20,6 +20,7 @@ when specified.
 import sys, configparser, telebot
 import getopt
 import logging
+import os.path
 
 
 logging.basicConfig(format='%(message)s')
@@ -27,7 +28,7 @@ log = logging.getLogger(__name__)
 
 
 def usage():
-    print (__doc__ % {'script_name': sys.argv[0].split('/')[-1]}, file=sys.stderr)
+    print (__doc__ % {'script_name': os.path.basename(sys.argv[0])}, file=sys.stderr)
 
 
 def parse_commandline(argv = sys.argv[1:]):

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Usage: %(script_name)s { -h | --help }
        %(script_name)s [ { -c | --config-file } FILE ]
@@ -23,10 +24,6 @@ import logging
 import os.path
 
 
-logging.basicConfig(format='%(message)s')
-log = logging.getLogger(__name__)
-
-
 def usage():
     print (__doc__ % {'script_name': os.path.basename(sys.argv[0])}, file=sys.stderr)
 
@@ -39,6 +36,7 @@ def parse_commandline(argv = sys.argv[1:]):
                 [ 'config-file=', 'help', 'telegram-id=' ]
         )
     except getopt.GetoptError as err:
+        log = logging.getLogger(__name__)
         log.error('Error parsing command line options: %s', err)
         usage()
         sys.exit(1)
@@ -48,38 +46,47 @@ def parse_commandline(argv = sys.argv[1:]):
         pass
 
 
-parse_commandline()
 
-config = configparser.ConfigParser()
+def main():
+    logging.basicConfig(format='%(message)s')
 
-# Open settings.ini file to retrieve API token
-try:
-	with open('settings.ini') as f:
-		config.read_file(f)
-except:
-	e = sys.exc_info()[1]
-	print(e)
-	sys.exit(1)
+    parse_commandline()
 
-token = config.get('TelegramSettings','API-Token')
+    config = configparser.ConfigParser()
 
-# initialise Bot 
-try:
-	bot = telebot.TeleBot(token) 
-	bot_info = bot.get_me()
-except:
-	e = sys.exc_info()[1]
-	print(e)
-	sys.exit(1)
+    # Open settings.ini file to retrieve API token
+    try:
+            with open('settings.ini') as f:
+                    config.read_file(f)
+    except:
+            e = sys.exc_info()[1]
+            print(e)
+            sys.exit(1)
 
-# Bot handlers below
-@bot.message_handler(commands=['start', 'help'])
-def send_welcome(message):
-	bot.reply_to(message, "Howdy, how are you doing?")
+    token = config.get('TelegramSettings','API-Token')
 
-@bot.message_handler(func=lambda message: True)
-def echo_all(message):
-	bot.reply_to(message, message.text)
+    # initialise Bot
+    try:
+            bot = telebot.TeleBot(token)
+            bot_info = bot.get_me()
+    except:
+            e = sys.exc_info()[1]
+            print(e)
+            sys.exit(1)
 
-# Start the bot
-bot.infinity_polling()
+    # Bot handlers below
+    @bot.message_handler(commands=['start', 'help'])
+    def send_welcome(message):
+            bot.reply_to(message, "Howdy, how are you doing?")
+
+    @bot.message_handler(func=lambda message: True)
+    def echo_all(message):
+            bot.reply_to(message, message.text)
+
+    # Start the bot
+    bot.infinity_polling()
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
Configuration can now be passed through the configuration file and command line parameters.

Command line parameters have precedence over config file parameters; this allows to override specific config for a bot instance, but use mostly the same configuration from a config file.
This is useful for multiple bot instances on the same server.

Also did some refactoring, so all code is now wrapped in a main() function.